### PR TITLE
Fixed action on workflow_call

### DIFF
--- a/.github/workflows/build_latex_workflow.yml
+++ b/.github/workflows/build_latex_workflow.yml
@@ -1,11 +1,6 @@
 name: Build LaTeX document
 
 on:
-  pull_request:
-    branches:
-      - main
-    types: [opened, synchronize, reopened]
-
   workflow_call:
     inputs:
       root_file:


### PR DESCRIPTION
This patch fixes an issue that affects both this repository and the ones that depend on it. The "on pull request" action should not apply to this repository, but to the repositories that invoke it.
The repositories to be modified are listed under `example-projects`, such as `example-notes`